### PR TITLE
fix(links): ignore the case when look-up for an anchor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -533,7 +533,7 @@ impl Inlyne {
                                             }
                                         }
                                     } else if let Some(anchor_pos) =
-                                        self.renderer.positioner.anchors.get(link)
+                                        self.renderer.positioner.anchors.get(&link.to_lowercase())
                                     {
                                         self.renderer.set_scroll_y(*anchor_pos);
                                         self.window.request_redraw();


### PR DESCRIPTION
- Closes: Inlyne-Project/inlyne/issues/255
